### PR TITLE
Fix the plots heights

### DIFF
--- a/src/pages/packet-loss-ml.py
+++ b/src/pages/packet-loss-ml.py
@@ -122,7 +122,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-pl-mean'),
+                    html.Div(id='results-table-pl-mean', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
 
@@ -133,7 +133,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-pl'),
+                    html.Div(id='results-table-pl', style={'height':'450px'}),
                 style={'height':'0.5rem'}, color='#00245A')
             ], className="m-2"),
         ], className="p-2 site boxwithshadow page-cont mb-2 g-0", justify="center", align="center"),
@@ -157,7 +157,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-pl-src'),
+                    html.Div(id='results-table-pl-src', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
         html.Br(),
@@ -166,7 +166,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-pl-mean-src'),
+                    html.Div(id='results-table-pl-mean-src', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
         ], className="p-2 site boxwithshadow page-cont mb-2 g-0", justify="center", align="center"),
@@ -177,7 +177,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-pl-dest'),
+                    html.Div(id='results-table-pl-dest', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
         html.Br(),
@@ -186,7 +186,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-pl-mean-dest'),
+                    html.Div(id='results-table-pl-mean-dest', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
         ], className="p-2 site boxwithshadow page-cont mb-2 g-0", justify="center", align="center"),
@@ -215,7 +215,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-pl-dest-src', style={'height':'400px'}),
+                    html.Div(id='results-table-pl-dest-src', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2", style={"padding-top": "1%"}),
             dbc.Row([
@@ -223,7 +223,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-pl-mean-dest-src', style={'height':'400px'}),
+                    html.Div(id='results-table-pl-mean-dest-src', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
         ], className="p-2 site boxwithshadow page-cont mb-2 g-0", align="center"),

--- a/src/pages/throughput-ml.py
+++ b/src/pages/throughput-ml.py
@@ -126,7 +126,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-thrpt-mean'),
+                    html.Div(id='results-table-thrpt-mean', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
 
@@ -137,7 +137,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-thrpt'),
+                    html.Div(id='results-table-thrpt', style={'height':'450px'}),
                 style={'height':'0.5rem'}, color='#00245A')
             ], className="m-2"),
         ], className="p-2 site boxwithshadow page-cont mb-2 g-0", justify="center", align="center"),
@@ -161,7 +161,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-thrpt-src'),
+                    html.Div(id='results-table-thrpt-src', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
         html.Br(),
@@ -170,7 +170,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-thrpt-mean-src'),
+                    html.Div(id='results-table-thrpt-mean-src', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
         ], className="p-2 site boxwithshadow page-cont mb-2 g-0", justify="center", align="center"),
@@ -181,7 +181,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-thrpt-dest'),
+                    html.Div(id='results-table-thrpt-dest', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
         html.Br(),
@@ -190,7 +190,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-thrpt-mean-dest'),
+                    html.Div(id='results-table-thrpt-mean-dest', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
         ], className="p-2 site boxwithshadow page-cont mb-2 g-0", justify="center", align="center"),
@@ -218,7 +218,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-thrpt-dest-src', style={'height':'400px'}),
+                    html.Div(id='results-table-thrpt-dest-src', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2", style={"padding-top": "1%"}),
             dbc.Row([
@@ -226,7 +226,7 @@ def layout(**other_unknown_query_strings):
                 html.Hr(className="my-2"),
                 html.Br(),
                 dcc.Loading(
-                    html.Div(id='results-table-thrpt-mean-dest-src', style={'height':'400px'}),
+                    html.Div(id='results-table-thrpt-mean-dest-src', style={'height':'450px'}),
                     style={'height': '0.5rem'}, color='#00245A')
             ], className="m-2"),
         ], className="p-2 site boxwithshadow page-cont mb-2 g-0", align="center"),


### PR DESCRIPTION
The responsive style of the plots sometimes makes them overlap other page elements. Setting a constant height for the parent divs fixes this.